### PR TITLE
disabling tenant scope upon a flag

### DIFF
--- a/lib/multitenancy/model_extensions.rb
+++ b/lib/multitenancy/model_extensions.rb
@@ -9,7 +9,7 @@ module Multitenancy
     
     module ClassMethods
       
-      def acts_as_tenant(tenant_id, sub_tenant_id=nil)
+      def acts_as_tenant(tenant_id, sub_tenant_id=nil, disable_tenant_scope = false)
         raise "tenant_id can't be nil! [Multitenancy]" unless tenant_id
         
         def self.is_scoped_by_tenant?
@@ -32,7 +32,7 @@ module Multitenancy
           tenant = Multitenancy.current_tenant
           if tenant && tenant.tenant_id
             conditions = {}
-            conditions[tenant_id] = tenant.tenant_id
+            conditions[tenant_id] = tenant.tenant_id unless disable_tenant_scope
             conditions[sub_tenant_id] = tenant.sub_tenant_id if sub_tenant_id && tenant.sub_tenant_id
             where(conditions)
           end

--- a/lib/multitenancy/version.rb
+++ b/lib/multitenancy/version.rb
@@ -1,3 +1,4 @@
 module Multitenancy
-  VERSION = "0.0.5"
+  # This is a patched version built out of branch disabling_tenant to avoid searching entities with tenant_id(while making select queries)
+  VERSION = "0.0.5.patched"
 end

--- a/lib/multitenancy/version.rb
+++ b/lib/multitenancy/version.rb
@@ -1,4 +1,4 @@
 module Multitenancy
   # This is a patched version built out of branch disabling_tenant to avoid searching entities with tenant_id(while making select queries)
-  VERSION = "0.0.5.patched"
+  VERSION = "0.0.6.patched"
 end


### PR DESCRIPTION
Done for OMS. As of now, all orders have same tenant_id, so removing this to eliminate unnecessary conditions in sql queries.
